### PR TITLE
Bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Cython=0.29.24
 ソースコードをコピーした後、Cythonコードを用いるためのコンパイルが必要です。
 ```
 git clone git@github.com:kainakajima11/limda.git
-cd .limda/src/limda
+cd limda/src/limda
 python3 setup.py build_ext --inplace
 ```
 ## Add Path

--- a/docs/SimulationFrame.md
+++ b/docs/SimulationFrame.md
@@ -335,14 +335,40 @@ sf.packmol(sf_list=[sf_h2o],
 ### lax()
 laxの計算を実行します.<br>
 ```python3
-sf.lax(calc_dir = "lax_calc" # 計算が行われるdir
-       lax_cmd = "lax" # lax fileがあるpath
-       lax_config = None # config.rdに必要な内容をdictで渡す.
-       print_lax = False,  # out fileを出力するか
+lax_config = {
+    "Mode":"MD",
+     "NNPModelPath":"/nfshome15/rkudo/work/lax_bench/train/model1/frozen_models/allegro_frozen_544000.pth",
+     "TotalStep":"100000",
+     "TimeStep":"0.50",
+     "FileStep":"100",
+     "SaveRestartStep":"0",
+     "MPIGridX":"1",
+     "MPIGridY":"1",
+     "MPIGridZ":"1",
+     "CUTOFF":"4.0",
+     "MARGIN":"1.0",
+     "GhostFactor":"20.0",
+     "InitTemp":"300.0",
+     "Thermo":"NoseHoover",
+     "AimTemp":"300.0",
+     "FinalTemp":"300.0",
+     "ThermoFreq":"10.0",
+     "Baro":"NoseHoover",
+     "PressFlag":"1 1 1",
+     "AimPress":"1.0 1.0 1.0",
+     "BaroFreq":"3000 3000 3000",
+     "FlagArrayUsage":"1",
+     "MaxPairNumberOfOneMeshDevided":"3000",
+}
+sf.lax(calc_dir = "lax_calc/lax_calc_0", # 計算が行われるdir
+       lax_cmd = "~/lax/src/build/lax", # 実行可能なlaxのpath
+       lax_config = lax_config, # config.rdに必要な内容をdictで渡す.
+       print_lax = True,  # out fileを出力するか
        exist_ok = False, # calc_dirが存在するときに実行するか
-       mask_info = "" # input.rdに書かれる#pressz、#moveなどの情報
-       # ex. mask_info = [#pressz 1 1 0", "#move 2 x 100 - - - -"] # mask 1にpress, mask 2にxmove
+       mask_info = [] # input.rdに書かれる#pressz、#moveなどの情報
+       # ex. mask_info = [#pressz 1 1 0", "#move 2 x 100 - - - -"] # mask 1にpress, mask 2にmove
        )
+
 ```
 ### allegro()
 sfに入っている原子の座標などから、かかる力とポテンシャルエネルギーを予測します.<br>

--- a/src/limda/calculate.py
+++ b/src/limda/calculate.py
@@ -155,9 +155,9 @@ class Calculate(
             exist_ok: bool
         """
         calc_dir = pathlib.Path(calc_dir)
-        if not exist_ok:
-            assert not calc_dir.exists(), "calc_dir exists."
-        calc_dir.mkdir()
+        if calc_dir.exists() and not exist_ok:
+            raise RuntimeError(f"calc_dir ({calc_dir}) exists")
+        calc_dir.mkdir(parents=True, exist_ok=exist_ok)
 
         if para_file_path is not None:
             para_file_path = pathlib.Path(para_file_path)

--- a/src/limda/import_frame.py
+++ b/src/limda/import_frame.py
@@ -31,6 +31,9 @@ class ImportFrame(
         if pathlib.Path.exists(limda_dot_path):
             with open(limda_dot_path, "r") as f:
                 self.limda_default = yaml.safe_load(f)
+        else:
+            self.limda_default = {}
+
 #-----------------------------------------------------------------------   
     def import_input(self, file_path: Union[str, pathlib.Path]) -> None: #ky
         """Laichのinputファイルを読み込み、
@@ -104,8 +107,7 @@ class ImportFrame(
             の場合、Cの原子のタイプが1, Hの原子のタイプが2, Oの原子のタイプが3, Nの原子のタイプが4となる
 
         """ 
-        if len(atom_symbol_list) == 0:
-            assert "para" in self.limda_default
+        if len(atom_symbol_list) == 0 and "para" in self.limda_default:
             atom_symbol_list = self.limda_default["para"]
         atom_symbol_to_type = {}
         type_list = [i for i in range(1, len(atom_symbol_list)+1)]


### PR DESCRIPTION
.limda.yamlが無い && sf.import_para_from_listを実行するときのエラーを修正
sf.lax, sf.packmol, sf.laichを実行するときで、calc_dir="dir1/dir2/dir3"のようにディレクトリの中のディレクトリで実行しようとする時のエラーを修正
typoの修正
sf.laxのlax_configで、すべてを文字列で指定できるように修正(文字列でなくてもok)
lax_config["MPIGridX"] = 1でもlax_config["MPIGridX"] = "1"でもok